### PR TITLE
Make ProxyAction working for older rex and ansible

### DIFF
--- a/app/lib/actions/middleware/proxy_batch_triggering.rb
+++ b/app/lib/actions/middleware/proxy_batch_triggering.rb
@@ -1,6 +1,6 @@
 module Actions
   module Middleware
-    class RemoteTaskTriggering < ::Dynflow::Middleware
+    class ProxyBatchTriggering < ::Dynflow::Middleware
       # If the event could result into sub tasks being planned, check if there are any RemoteTasks
       # to trigger after the event is processed
       #

--- a/app/lib/actions/middleware/remote_task_triggering.rb
+++ b/app/lib/actions/middleware/remote_task_triggering.rb
@@ -3,6 +3,8 @@ module Actions
     class RemoteTaskTriggering < ::Dynflow::Middleware
       # If the event could result into sub tasks being planned, check if there are any RemoteTasks
       # to trigger after the event is processed
+      #
+      # The ProxyAction needs to be planned with `:use_batch_triggering => true` to activate the feature
       def run(event = nil)
         pass event
       ensure

--- a/app/lib/actions/proxy_action.rb
+++ b/app/lib/actions/proxy_action.rb
@@ -28,7 +28,7 @@ module Actions
       default_connection_options.each { |key, value| options[:connection_options][key] ||= value }
       plan_self(options.merge(:proxy_url => proxy.url, :proxy_action_name => klass.to_s, :proxy_version => proxy_version(proxy)))
       # Just saving the RemoteTask is enough when using batch triggering
-      # It will be picked up by the RemoteTaskTriggering middleware
+      # It will be picked up by the ProxyBatchTriggering middleware
       if input[:use_batch_triggering] && with_batch_triggering?(input[:proxy_version])
         prepare_remote_task.save!
       end


### PR DESCRIPTION
I was able to get into a situation with rex that was not having the change yet, that the task was actually not triggered. Just to make the release easier, it would be good new foreman-tasks would still work with older rex and ansible release.

I've also renamed `RemoteTaskTriggering` middleware to `ProxyBatchTriggering`, as it looks like better description of the responsibility for this middleware.