### PR TITLE
Refs #25736 - keep mdc after the middleware

### DIFF
--- a/app/lib/actions/middleware/keep_current_request_id.rb
+++ b/app/lib/actions/middleware/keep_current_request_id.rb
@@ -41,14 +41,18 @@ module Actions
       def restore_current_request_id
         if (restored_id = action.input[:current_request_id]).present?
           old_id = ::Logging.mdc['request']
-          ::Logging.mdc['request'] = restored_id
           if old_id.present? && old_id != restored_id
             action.action_logger.warn(_('Changing request id %{request_id} to saved id %{saved_id}') % { :saved_id => restored_id, :request_id => old_id })
           end
+          ::Logging.mdc['request'] = restored_id
         end
         yield
       ensure
-        ::Logging.mdc['request'] = nil
+        # Reset to original request id only when not nil
+        # Otherwise, keep the id until it's cleaned in  Dynflow's run_user_code block
+        # so that it will stay valid for the rest of the processing of the current step
+        # (even outside of the middleware lifecycle)
+        ::Logging.mdc['request'] = old_id if old_id.present?
       end
     end
   end


### PR DESCRIPTION
And rely on Dynlfow's `run_user_code` to clean it once not needed.

I've noticed that exceptions logged by dynflow didin't have the request id, because there are logged
outside of the middleware stack. Seems like keeping it until the use code runs is the simplest solution
to cover most of the cases.

Corresponding dynflow changes are here https://github.com/Dynflow/dynflow/pull/315